### PR TITLE
[INVESTDEV-710] Add support for ssh directory (rather than one key) to the common test action

### DIFF
--- a/.github/common_test/action.yaml
+++ b/.github/common_test/action.yaml
@@ -44,6 +44,7 @@ runs:
       set -eu
       mkdir -p ~/.ssh
       if [ -f ./deploy/id_rsa ]; then cp ./deploy/id_rsa ~/.ssh/id_rsa && chmod 600 ~/.ssh/id_rsa; fi
+      if [ -d ./deploy/ssh ]; then cp ./deploy/ssh/* ~/.ssh/ && chmod 600 ~/.ssh/id_*; fi
       poetry install --no-interaction
       poetry run pip install -U "pip${{ inputs.PIP_VERSION_SPEC }}"
   - name: Run checks


### PR DESCRIPTION
Has to be done because github cannot grant deploy-key access to multiple repositories to one ssh key.