### PR TITLE
Move django from group to extras

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,16 +2,16 @@
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
 name = "asgiref"
 version = "3.5.2"
 description = "ASGI specs, helper code, and adapters"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -216,8 +216,8 @@ python-versions = "*"
 name = "Django"
 version = "4.1.2"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.8"
 
 [package.dependencies]
@@ -233,8 +233,8 @@ bcrypt = ["bcrypt"]
 name = "django-coverage-plugin"
 version = "2.0.3"
 description = "Django template coverage.py plugin"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -245,8 +245,8 @@ six = ">=1.4.0"
 name = "django-debug-toolbar"
 version = "3.7.0"
 description = "A configurable set of panels that display various debug information about the current request/response."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -257,8 +257,8 @@ sqlparse = ">=0.2.0"
 name = "django-extra-checks"
 version = "0.13.0"
 description = "Collection of useful checks for Django Checks Framework"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.extras]
@@ -269,8 +269,8 @@ test = ["pytest", "pytest-cov", "pytest-django"]
 name = "django-migration-linter"
 version = "4.1.0"
 description = "Detect backward incompatible migrations for your django project"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -285,24 +285,24 @@ test = ["coverage (>=5.5)", "django-add-default-value (>=0.4.0)", "mysqlclient (
 name = "django-querycount"
 version = "0.7.0"
 description = "Middleware that Prints the number of DB queries to the runserver console."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [[package]]
 name = "django-split-settings"
 version = "1.2.0"
 description = "Organize Django settings into multiple files and directories. Easily override and modify settings. Use wildcards and optional settings files."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7,<4.0"
 
 [[package]]
 name = "django-stubs-ext"
 version = "0.5.0"
 description = "Monkey-patching and extensions for django-stubs"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -313,8 +313,8 @@ typing-extensions = "*"
 name = "django-test-migrations"
 version = "1.2.0"
 description = "Test django schema and data migrations, including ordering"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
@@ -389,8 +389,8 @@ pycodestyle = "*"
 name = "flake8-django"
 version = "1.1.5"
 description = "Plugin to catch bad style specific to Django Projects."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
@@ -891,8 +891,8 @@ pytest = ">=3.0.0"
 name = "pytest-django"
 version = "4.5.2"
 description = "A Django plugin for pytest."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -993,8 +993,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "sqlparse"
 version = "0.4.3"
 description = "A non-validating SQL parser."
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -1041,8 +1041,8 @@ python-versions = ">=3.7"
 name = "tzdata"
 version = "2022.5"
 description = "Provider of IANA time zone data"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = ">=2"
 
 [[package]]
@@ -1094,10 +1094,13 @@ python-versions = "*"
 [package.dependencies]
 cffi = ">=1.0"
 
+[extras]
+django = ["django-extra-checks", "django-test-migrations", "django-debug-toolbar", "django-querycount", "django-migration-linter", "flake8-django", "pytest-django", "django-coverage-plugin", "django-stubs-ext", "django-split-settings"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "8ec8c29974e06131d278437b0959faa6a3108832ae13e023e133a92d05817258"
+content-hash = "b5fa25918cd99895e1a24367eeb70143612abdff540effa456df1b810d9900ed"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,21 +39,33 @@ pytest-timeout = "^2.1.0"
 python = "^3.10"
 autoflake = "^1.5.3"
 toml = "^0.10.2"
+django-extra-checks = {version = "^0.13.0", optional = true}
+django-test-migrations = {version = "^1.2.0", optional = true}
+django-debug-toolbar = {version = "^3.7.0", optional = true}
+django-querycount = {version = "^0.7.0", optional = true}
+django-migration-linter = {version = "^4.1.0", optional = true}
+flake8-django = {version = "^1.1.5", optional = true}
+pytest-django = {version = "^4.5.2", optional = true}
+django-coverage-plugin = {version = "^2.0.3", optional = true}
+django-stubs-ext = {version = "^0.5.0", optional = true}
+django-split-settings = {version = "^1.2.0", optional = true}
+
+[tool.poetry.extras]
+django = [
+  "django-extra-checks",
+  "django-test-migrations",
+  "django-debug-toolbar",
+  "django-querycount",
+  "django-migration-linter",
+  "flake8-django",
+  "pytest-django",
+  "django-coverage-plugin",
+  "django-stubs-ext",
+  "django-split-settings",
+]
 
 [tool.poetry.group.dev.dependencies]
 types-toml = "^0.10.8"
-
-[tool.poetry.group.django.dependencies]
-django-extra-checks = "^0.13.0"
-django-test-migrations = "^1.2.0"
-django-debug-toolbar = "^3.7.0"
-django-querycount = "^0.7.0"
-django-migration-linter = "^4.1.0"
-flake8-django = "^1.1.5"
-pytest-django = "^4.5.2"
-django-coverage-plugin = "^2.0.3"
-django-stubs-ext = "^0.5.0"
-django-split-settings = "^1.2.0"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]


### PR DESCRIPTION
Путь: `poetry add --optional $pkgs` + `tool.poetry.extras` без версий.

Проверка: `git clean -d -x -f && python -m build && unp -u dist/*.whl && egrep -i 'provides|extra' */*/METADATA`

Должно быть: `Provides-Extra: django` + `Requires-Dist: django-extra-checks (>=0.13.0,<0.14.0); extra == "django"`